### PR TITLE
Add MIDI gadget

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following pre-defined USB functions, implemented by kernel drivers, are avai
     * generic
 * human interface device (HID)
 * mass-storage device (MSD)
+* musical instrument digital interface (MIDI)
 
 In addition fully custom USB functions can be implemented in user-mode Rust code.
 
@@ -58,6 +59,7 @@ The following Linux kernel configuration options should be enabled for full func
   * `CONFIG_USB_CONFIGFS_MASS_STORAGE`
   * `CONFIG_USB_CONFIGFS_F_FS`
   * `CONFIG_USB_CONFIGFS_F_HID`
+  * `CONFIG_USB_CONFIGFS_F_MIDI`
 
 root permissions are required to configure USB gadgets on Linux and
 the `configfs` filesystem needs to be mounted.

--- a/src/function/midi.rs
+++ b/src/function/midi.rs
@@ -1,6 +1,39 @@
 //! Musical Instrument Digital Interface (MIDI) function.
 //!
 //! The Linux kernel configuration option `CONFIG_USB_CONFIGFS_F_MIDI` must be enabled. Can use `amidi -l` once the gadget is configured to list the MIDI devices.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use usb_gadget::function::midi::Midi;
+//! use usb_gadget::{default_udc, Class, Config, Gadget, Id, Strings};
+//!
+//! let mut builder = Midi::builder();
+//! // This must be an available sound device index - see docs on index for more information
+//! builder.index = 0;
+//! builder.id = "midi".to_string();
+//! builder.in_ports = 1;
+//! builder.out_ports = 1;
+//! let (midi, func) = builder.build();
+//!
+//! let udc = default_udc().expect("cannot get UDC");
+//! let reg =
+//!     // USB device descriptor base class 0, 0, 0: use Interface Descriptors
+//!     // Linux Foundation VID Gadget PID
+//!     Gadget::new(Class::new(0, 0, 0), Id::new(0x1d6b, 0x0104), Strings::new("Clippy Manufacturer", "Rust MIDI", "RUST0123456"))
+//!         .with_config(Config::new("MIDI Config 1").with_function(func))
+//!         .bind(&udc)
+//!         .expect("cannot bind to UDC");
+//!
+//! println!(
+//!     "USB MIDI {} at {} to {} status {:?}",
+//!     reg.name().to_string_lossy(),
+//!     reg.path().display(),
+//!     udc.name().to_string_lossy(),
+//!     midi.status()
+//! );
+//! ```
+
 
 use std::{ffi::OsString, io::Result};
 

--- a/src/function/midi.rs
+++ b/src/function/midi.rs
@@ -1,0 +1,98 @@
+//! Musical Instrument Digital Interface (MIDI) function.
+//!
+//! The Linux kernel configuration option `CONFIG_USB_CONFIGFS_F_MIDI` must be enabled.
+
+use std::{
+    ffi::OsString,
+    io::{Error, ErrorKind, Result},
+};
+
+use super::{
+    util::{FunctionDir, Status},
+    Function, Handle,
+};
+
+/// Builder for USB musical instrument digital interface (MIDI) function.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct MidiBuilder {
+    /// MIDI buffer length
+    pub buflen: u16,
+    /// ID string for the USB MIDI adapter
+    pub id: String,
+    /// Number of MIDI input ports
+    pub in_ports: u8,
+    /// Number of MIDI output ports
+    pub out_ports: u8,
+    /// Index value for the USB MIDI adapter.
+    pub index: u8,
+    /// USB read request queue length
+    pub qlen: u8,
+}
+
+impl MidiBuilder {
+    /// Build the USB function.
+    ///
+    /// The returned handle must be added to a USB gadget configuration.
+    pub fn build(self) -> (Midi, Handle) {
+        let dir = FunctionDir::new();
+        (Midi { dir: dir.clone() }, Handle::new(MidiFunction { builder: self, dir }))
+    }
+}
+
+#[derive(Debug)]
+struct MidiFunction {
+    builder: MidiBuilder,
+    dir: FunctionDir,
+}
+
+impl Function for MidiFunction {
+    fn driver(&self) -> OsString {
+        "midi".into()
+    }
+
+    fn dir(&self) -> FunctionDir {
+        self.dir.clone()
+    }
+
+    fn register(&self) -> Result<()> {
+        self.dir.write("buflen", self.builder.buflen.to_string())?;
+        self.dir.write("id", &self.builder.id)?;
+        self.dir.write("in_ports", &self.builder.in_ports.to_string())?;
+        self.dir.write("out_ports", self.builder.out_ports.to_string())?;
+        self.dir.write("index", self.builder.index.to_string())?;
+        self.dir.write("qlen", self.builder.qlen.to_string())?;
+
+        Ok(())
+    }
+}
+
+/// USB musical instrument digital interface (MIDI) function.
+#[derive(Debug)]
+pub struct Midi {
+    dir: FunctionDir,
+}
+
+impl Midi {
+    /// Creates a new USB musical instrument digital interface (MIDI) builder.
+    pub fn builder() -> MidiBuilder {
+        MidiBuilder { buflen: 0, id: String::new(), in_ports: 0, out_ports: 0, index: 0, qlen: 0 }
+    }
+
+    /// Access to registration status.
+    pub fn status(&self) -> Status {
+        self.dir.status()
+    }
+
+    /// Device major and minor numbers.
+    pub fn device(&self) -> Result<(u32, u32)> {
+        let dev = self.dir.read_string("dev")?;
+        let Some((major, minor)) = dev.split_once(':') else {
+            return Err(Error::new(ErrorKind::InvalidData, "invalid device number format"));
+        };
+        let major = major.parse().map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
+        let minor = minor.parse().map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
+
+        Ok((major, minor))
+    }
+}

--- a/src/function/midi.rs
+++ b/src/function/midi.rs
@@ -1,6 +1,7 @@
 //! Musical Instrument Digital Interface (MIDI) function.
 //!
-//! The Linux kernel configuration option `CONFIG_USB_CONFIGFS_F_MIDI` must be enabled. Can use `amidi -l` once the gadget is configured to list the MIDI devices.
+//! The Linux kernel configuration option `CONFIG_USB_CONFIGFS_F_MIDI` must be enabled.
+//! Can use `amidi -l` once the gadget is configured to list the MIDI devices.
 //!
 //! # Example
 //!
@@ -32,17 +33,17 @@
 //! );
 //! ```
 
-
 use std::{ffi::OsString, io::Result};
 
 use super::{
-    util::{FunctionDir, Status, write_opt},
+    util::{FunctionDir, Status},
     Function, Handle,
 };
 
-/// Builder for USB musical instrument digital interface (MIDI) function. 
+/// Builder for USB musical instrument digital interface (MIDI) function.
 ///
-/// None value will use the f_midi module default. See drivers/usb/gadget/function/f_midi.c#L1274.
+/// None value will use the f_midi module default.
+/// See `drivers/usb/gadget/function/f_midi.c#L1274`.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct MidiBuilder {
@@ -54,9 +55,16 @@ pub struct MidiBuilder {
     pub in_ports: Option<u8>,
     /// Number of MIDI output ports
     pub out_ports: Option<u8>,
-    /// Sound device index for the MIDI adapter. None for automatic selection.
+    /// Sound device index for the MIDI adapter.
+    /// `None` for automatic selection.
     ///
-    /// There must be a sound device available with this index. If the device fails to register and in dmesg one sees 'cannot find the slot for index $index (range 0-1), error: -16', then the index is not available. Most likely the index is already in use by the physical sound card. Try another index within range or unload the physical sound card driver. See [USB Gadget MIDI](https://linux-sunxi.org/USB_Gadget/MIDI).
+    /// There must be a sound device available with this index.
+    /// If the device fails to register and in dmesg one sees
+    /// `cannot find the slot for index $index (range 0-1), error: -16`,
+    /// then the index is not available.
+    /// Most likely the index is already in use by the physical sound card. T
+    /// ry another index within range or unload the physical sound card driver.
+    /// See [USB Gadget MIDI](https://linux-sunxi.org/USB_Gadget/MIDI).
     pub index: Option<u8>,
     /// USB read request queue length
     pub qlen: Option<u8>,
@@ -88,12 +96,29 @@ impl Function for MidiFunction {
     }
 
     fn register(&self) -> Result<()> {
-        write_opt!(self.dir, "buflen", self.builder.buflen);
-        write_opt!(self.dir, "id", self.builder.id.as_ref());
-        write_opt!(self.dir, "in_ports", self.builder.in_ports);
-        write_opt!(self.dir, "out_ports", self.builder.out_ports);
-        write_opt!(self.dir, "index", self.builder.index);
-        write_opt!(self.dir, "qlen", self.builder.qlen);
+        if let Some(buflen) = self.builder.buflen {
+            self.dir.write("buflen", buflen.to_string())?;
+        }
+
+        if let Some(id) = &self.builder.id {
+            self.dir.write("id", id)?;
+        }
+
+        if let Some(in_ports) = self.builder.in_ports {
+            self.dir.write("in_ports", in_ports.to_string())?;
+        }
+
+        if let Some(out_ports) = self.builder.out_ports {
+            self.dir.write("out_ports", out_ports.to_string())?;
+        }
+
+        if let Some(index) = self.builder.index {
+            self.dir.write("index", index.to_string())?;
+        }
+
+        if let Some(qlen) = self.builder.qlen {
+            self.dir.write("qlen", qlen.to_string())?;
+        }
 
         Ok(())
     }

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -6,6 +6,7 @@ pub mod msd;
 pub mod net;
 pub mod other;
 pub mod serial;
+pub mod midi;
 pub mod util;
 
 use std::{cmp, hash, hash::Hash, sync::Arc};

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -2,11 +2,11 @@
 
 pub mod custom;
 pub mod hid;
+pub mod midi;
 pub mod msd;
 pub mod net;
 pub mod other;
 pub mod serial;
-pub mod midi;
 pub mod util;
 
 use std::{cmp, hash, hash::Hash, sync::Arc};

--- a/src/function/util.rs
+++ b/src/function/util.rs
@@ -12,17 +12,6 @@ use std::{
 
 use crate::{function::register_remove_handlers, trim_os_str};
 
-/// Write an optional value to the function directory if not None.
-macro_rules! write_opt {
-    ($dir:expr, $name:expr, $value:expr) => {
-        if let Some(value) = $value {
-            $dir.write($name, value.to_string())?;
-        }
-    };
-}
-
-pub(super) use write_opt;
-
 /// USB gadget function.
 pub trait Function: fmt::Debug + Send + Sync + 'static {
     /// Name of the function driver.

--- a/src/function/util.rs
+++ b/src/function/util.rs
@@ -12,6 +12,17 @@ use std::{
 
 use crate::{function::register_remove_handlers, trim_os_str};
 
+/// Write an optional value to the function directory if not None.
+macro_rules! write_opt {
+    ($dir:expr, $name:expr, $value:expr) => {
+        if let Some(value) = $value {
+            $dir.write($name, value.to_string())?;
+        }
+    };
+}
+
+pub(super) use write_opt;
+
 /// USB gadget function.
 pub trait Function: fmt::Debug + Send + Sync + 'static {
     /// Name of the function driver.

--- a/tests/midi.rs
+++ b/tests/midi.rs
@@ -3,22 +3,23 @@ use common::*;
 
 use usb_gadget::function::midi::Midi;
 
+// Ignored because it requires sound device index to be available which is not common on most systems
+// on Raspberry Pi, the index is already in use by HDMI audio. Append 'noaudio' to 'dtoverlay=vc4-kms-v3d,noaudio' in /boot/config.txt: https://www.raspberrypi.com/documentation/computers/config_txt.html#hdmi-audio
+#[ignore]
 #[test]
 fn midi() {
     init();
 
     let mut builder = Midi::builder();
-    builder.buflen = 64;
+    builder.index = 0;
     builder.id = "midi".to_string();
     builder.in_ports = 1;
     builder.out_ports = 1;
-    builder.index = 0;
-    builder.qlen = 8;
     let (midi, func) = builder.build();
 
     let reg = reg(func);
 
-    println!("midi device {:?} at {}", midi.device().unwrap(), midi.status().path().unwrap().display());
+    println!("midi device at {}", midi.status().path().unwrap().display());
 
     unreg(reg).unwrap();
 }

--- a/tests/midi.rs
+++ b/tests/midi.rs
@@ -1,0 +1,24 @@
+mod common;
+use common::*;
+
+use usb_gadget::function::midi::Midi;
+
+#[test]
+fn midi() {
+    init();
+
+    let mut builder = Midi::builder();
+    builder.buflen = 64;
+    builder.id = "midi".to_string();
+    builder.in_ports = 1;
+    builder.out_ports = 1;
+    builder.index = 0;
+    builder.qlen = 8;
+    let (midi, func) = builder.build();
+
+    let reg = reg(func);
+
+    println!("midi device {:?} at {}", midi.device().unwrap(), midi.status().path().unwrap().display());
+
+    unreg(reg).unwrap();
+}

--- a/tests/midi.rs
+++ b/tests/midi.rs
@@ -3,18 +3,14 @@ use common::*;
 
 use usb_gadget::function::midi::Midi;
 
-// Ignored because it requires sound device index to be available which is not common on most systems
-// on Raspberry Pi, the index is already in use by HDMI audio. Append 'noaudio' to 'dtoverlay=vc4-kms-v3d,noaudio' in /boot/config.txt: https://www.raspberrypi.com/documentation/computers/config_txt.html#hdmi-audio
-#[ignore]
 #[test]
 fn midi() {
     init();
 
     let mut builder = Midi::builder();
-    builder.index = 0;
-    builder.id = "midi".to_string();
-    builder.in_ports = 1;
-    builder.out_ports = 1;
+    builder.id = Some("midi".to_string());
+    builder.in_ports = Some(1);
+    builder.out_ports = Some(1);
     let (midi, func) = builder.build();
 
     let reg = reg(func);


### PR DESCRIPTION
Mostly boilerplate code to support [f_midi](https://github.com/torvalds/linux/blob/master/drivers/usb/gadget/function/f_midi.c). I wanted to use it though so useful to include I think.

I added a test but `#[ignore]` because my test device (Raspberry Pi 5) required disabling HDMI audio so that the f_midi module could be the primary sound device. I also tested with `index = 1` but believe HDMI audio uses both indexes. I added some docs to the index property to make this clear since it took a bit of digging for me.