### PR TITLE
Add UVC for video gadget

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following pre-defined USB functions, implemented by kernel drivers, are avai
 * mass-storage device (MSD)
 * musical instrument digital interface (MIDI)
 * audio device (UAC2)
+* video device (UVC)
 
 In addition fully custom USB functions can be implemented in user-mode Rust code.
 
@@ -62,6 +63,7 @@ The following Linux kernel configuration options should be enabled for full func
   * `CONFIG_USB_CONFIGFS_F_HID`
   * `CONFIG_USB_CONFIGFS_F_MIDI`
   * `CONFIG_USB_CONFIGFS_F_UAC2`
+  * `CONFIG_USB_CONFIGFS_F_UVC`
 
 root permissions are required to configure USB gadgets on Linux and
 the `configfs` filesystem needs to be mounted.

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -9,6 +9,7 @@ pub mod net;
 pub mod other;
 pub mod serial;
 pub mod util;
+pub mod video;
 
 use std::{cmp, hash, hash::Hash, sync::Arc};
 
@@ -63,4 +64,5 @@ impl Hash for Handle {
 fn register_remove_handlers() {
     register_remove_handler(custom::driver(), custom::remove_handler);
     register_remove_handler(msd::driver(), msd::remove_handler);
+    register_remove_handler(video::driver(), video::remove_handler);
 }

--- a/src/function/util.rs
+++ b/src/function/util.rs
@@ -205,6 +205,13 @@ impl FunctionDir {
         fs::create_dir(path)
     }
 
+    /// Create a subdirectory and its parent directories.
+    pub fn create_dir_all(&self, name: impl AsRef<Path>) -> Result<()> {
+        let path = self.property_path(name)?;
+        log::debug!("creating directorys {}", path.display());
+        fs::create_dir_all(path)
+    }
+
     /// Remove a subdirectory.
     pub fn remove_dir(&self, name: impl AsRef<Path>) -> Result<()> {
         let path = self.property_path(name)?;
@@ -248,6 +255,14 @@ impl FunctionDir {
         let value = value.as_ref();
         log::debug!("setting property {} to {}", path.display(), String::from_utf8_lossy(value));
         fs::write(path, value)
+    }
+
+    /// Create a symbolic link.
+    pub fn symlink(&self, target: impl AsRef<Path>, link: impl AsRef<Path>) -> Result<()> {
+        let target = self.property_path(target)?;
+        let link = self.property_path(link)?;
+        log::debug!("creating symlink {} -> {}", link.display(), target.display());
+        std::os::unix::fs::symlink(target, link)
     }
 }
 

--- a/src/function/video.rs
+++ b/src/function/video.rs
@@ -151,7 +151,7 @@ impl From<Frame> for UvcFrame {
         UvcFrame {
             width: frame.width,
             height: frame.height,
-            intervals: frame.fps.iter().map(|i| (1_000_000_000 / *i as u32)).collect(),
+            intervals: frame.fps.iter().filter(|i| **i != 0).map(|i| (1_000_000_000 / *i as u32)).collect(),
             color_matching: None,
             format: frame.format,
         }
@@ -237,6 +237,10 @@ impl Function for UvcFunction {
     fn register(&self) -> Result<()> {
         if self.builder.frames.is_empty() {
             return Err(Error::new(ErrorKind::InvalidInput, "at least one frame must exist"));
+        }
+
+        if self.builder.frames.iter().any(|f| f.intervals.is_empty()) {
+            return Err(Error::new(ErrorKind::InvalidInput, "at least one interval must exist for every frame"));
         }
 
         // format groups to link to header

--- a/src/function/video.rs
+++ b/src/function/video.rs
@@ -219,14 +219,17 @@ impl Function for UvcFunction {
                 self.dir.symlink("control/header/h", "control/class/fs/h")?;
             }
             Some(Speed::HighSpeed) => {
+                self.dir.symlink("streaming/header/h", "streaming/class/fs/h")?;
                 self.dir.symlink("streaming/header/h", "streaming/class/hs/h")?;
-                self.dir.symlink("control/header/h", "control/class/hs/h")?;
+                self.dir.symlink("control/header/h", "control/class/fs/h")?;
             }
             Some(Speed::SuperSpeed) => {
+                self.dir.symlink("streaming/header/h", "streaming/class/fs/h")?;
+                self.dir.symlink("streaming/header/h", "streaming/class/hs/h")?;
                 self.dir.symlink("streaming/header/h", "streaming/class/ss/h")?;
+                self.dir.symlink("control/header/h", "control/class/fs/h")?;
                 self.dir.symlink("control/header/h", "control/class/ss/h")?;
             }
-            // default to all speeds
             _ => {
                 self.dir.symlink("streaming/header/h", "streaming/class/fs/h")?;
                 self.dir.symlink("streaming/header/h", "streaming/class/hs/h")?;

--- a/src/function/video.rs
+++ b/src/function/video.rs
@@ -1,0 +1,319 @@
+//! USB Video Class (UVC) function.
+//!
+//! The Linux kernel configuration option `CONFIG_USB_CONFIGFS_F_UVC` must be enabled.
+use std::{
+    ffi::{OsStr, OsString}, io::{Error, ErrorKind, Result}, path::PathBuf,
+    fs,
+};
+
+use super::{
+    util::{FunctionDir, Status},
+    Function, Handle,
+};
+
+pub(crate) fn driver() -> &'static OsStr {
+    OsStr::new("uvc")
+}
+
+/// USB Video Class (UVC) frame format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum UvcFormat {
+    /// YUYV format [Packed YUV formats](https://docs.kernel.org/6.12/userspace-api/media/v4l/pixfmt-packed-yuv.html). Currently only uncompressed format supported.
+    Yuyv,
+    /// MJPEG compressed format.
+    Mjpeg,
+}
+
+impl UvcFormat {
+    fn all() -> &'static [UvcFormat] {
+        &[UvcFormat::Yuyv, UvcFormat::Mjpeg]
+    }
+
+    fn dir_name(&self) -> &'static OsStr {
+        match self {
+            UvcFormat::Yuyv => OsStr::new("yuyv"),
+            UvcFormat::Mjpeg => OsStr::new("mjpeg"),
+        }
+    }
+
+    fn group_path(&self) -> PathBuf {
+        format!("streaming/{}/{}", self.group_dir_name().to_string_lossy(), self.dir_name().to_string_lossy()).into()
+    }
+
+    fn color_matching_path(&self) -> PathBuf {
+        format!("streaming/color_matching/{}", self.dir_name().to_string_lossy()).into()
+    }
+
+    fn header_link_path(&self) -> PathBuf {
+        format!("streaming/header/h/{}", self.dir_name().to_string_lossy()).into()
+    }
+
+    fn group_dir_name(&self) -> &'static OsStr {
+        match self {
+            UvcFormat::Yuyv => OsStr::new("uncompressed"),
+            _ => self.dir_name(),
+        }
+    }
+}
+
+/// Frame color matching information properties.
+///
+/// It’s possible to specify some colometry information for each format you
+/// create. This step is optional, and default information will be included if
+/// this step is skipped; those default values follow those defined in the
+/// Color Matching Descriptor section of the UVC specification.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct UvcColorMatching {
+    /// Color primaries
+    pub color_primaries: u8,
+    /// Transfer characteristics
+    pub transfer_characteristics: u8,
+    /// Matrix coefficients
+    pub matrix_coefficients: u8,
+}
+
+impl UvcColorMatching {
+    /// Create a new color matching information with the specified properties.
+    pub fn new(color_primaries: u8, transfer_characteristics: u8, matrix_coefficients: u8) -> Self {
+        Self { color_primaries, transfer_characteristics, matrix_coefficients }
+    }
+}
+
+/// USB Video Class (UVC) frame configuration.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct UvcFrame {
+    /// Frame width in pixels
+    pub width: u32,
+    /// Frame height in pixels
+    pub height: u32,
+    /// Frame intervals available each in 100 ns units
+    pub intervals: Vec<u32>,
+    /// Color matching information. If not provided, the default values are used.
+    pub color_matching: Option<UvcColorMatching>,
+    /// Frame format
+    pub format: UvcFormat,
+}
+
+impl UvcFrame {
+    fn dir_name(&self) -> String {
+        format!("{}p", self.height)
+    }
+
+    fn group_path(&self) -> PathBuf {
+        self.format.group_path()
+    }
+
+    fn color_matching_path(&self) -> PathBuf {
+        self.format.color_matching_path()
+    }
+
+    fn header_link_path(&self) -> PathBuf {
+        self.format.header_link_path()
+    }
+
+    fn path(&self) -> PathBuf {
+        self.group_path().join(&self.dir_name())
+    }
+}
+
+/// Builder for USB Video Class (UVC) function.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct UvcBuilder {
+    /// Interval for polling endpoint for data transfers
+    pub streaming_interval: Option<u8>,
+    /// bMaxBurst for super speed companion descriptor. Valid values are 1-15.
+    pub streaming_max_burst: Option<u8>,
+    /// Maximum packet size this endpoint is capable of sending or receiving when this configuration is selected. Valid values are 1024/2048/3072.
+    pub streaming_max_packet: Option<u32>,
+    /// Video device interface name
+    pub function_name: Option<String>,
+    /// Video frames available
+    pub frames: Vec<UvcFrame>,
+    /// Processing Unit's bmControls field
+    pub processing_controls: Option<u8>,
+    /// Camera Terminal's bmControls field
+    pub camera_controls: Option<u8>,
+}
+
+impl UvcBuilder {
+    /// Build the USB function.
+    ///
+    /// The returned handle must be added to a USB gadget configuration.
+    pub fn build(self) -> (Uvc, Handle) {
+        let dir = FunctionDir::new();
+        (Uvc { dir: dir.clone() }, Handle::new(UvcFunction { builder: self, dir }))
+    }
+}
+
+#[derive(Debug)]
+struct UvcFunction {
+    builder: UvcBuilder,
+    dir: FunctionDir,
+}
+
+impl Function for UvcFunction {
+    fn driver(&self) -> OsString {
+        driver().into()
+    }
+
+    fn dir(&self) -> FunctionDir {
+        self.dir.clone()
+    }
+
+    fn register(&self) -> Result<()> {
+        if self.builder.frames.is_empty() {
+            return Err(Error::new(ErrorKind::InvalidInput, "at least one frame must exist"));
+        }
+
+        for frame in self.builder.frames.iter() {
+            self.dir.create_dir_all(frame.path())?;
+            self.dir.write(frame.path().join("wWidth"), frame.width.to_string())?;
+            self.dir.write(frame.path().join("wHeight"), frame.height.to_string())?;
+            self.dir.write(frame.path().join("dwMaxVideoFrameBufferSize"), (frame.width * frame.height * 2).to_string())?;
+            self.dir.write(frame.path().join("dwFrameInterval"), frame.intervals.iter().map(|i| i.to_string()).collect::<Vec<String>>().join("\n"))?;
+
+            if let Some(color_matching) = frame.color_matching.as_ref() {
+                let color_matching_path = frame.color_matching_path();
+                // can only have one color matching information per format
+                if !color_matching_path.is_dir() {
+                    self.dir.create_dir_all(&color_matching_path)?;
+                    self.dir.write(frame.color_matching_path().join("bColorPrimaries"), color_matching.color_primaries.to_string())?;
+                    self.dir.write(frame.color_matching_path().join("bTransferCharacteristics"), color_matching.transfer_characteristics.to_string())?;
+                    self.dir.write(frame.color_matching_path().join("bMatrixCoefficients"), color_matching.matrix_coefficients.to_string())?;
+                    self.dir.symlink(&color_matching_path, frame.group_path())?;
+                } else {
+                    log::warn!("Color matching information already exists for format {:?}", frame.format);
+                }
+            }
+        }
+
+        // header linking format descriptors and associated frames to header after creating
+        // otherwise cannot add new frames
+        self.dir.create_dir_all("streaming/header/h")?;
+        for frame in &self.builder.frames {
+            if !self.dir.property_path(frame.header_link_path())?.is_symlink() {
+                self.dir.symlink(frame.group_path(), frame.header_link_path())?;
+            }
+        }
+
+        // supported speeds
+        self.dir.symlink("streaming/header/h", "streaming/class/fs/h")?;
+        self.dir.symlink("streaming/header/h", "streaming/class/hs/h")?;
+        self.dir.symlink("streaming/header/h", "streaming/class/ss/h")?;
+        self.dir.create_dir_all("control/header/h")?;
+        self.dir.symlink("control/header/h", "control/class/fs/h")?;
+        self.dir.symlink("control/header/h", "control/class/ss/h")?;
+
+        // bandwidth configuration
+        if let Some(interval) = self.builder.streaming_interval {
+            self.dir.write("streaming_interval", interval.to_string())?;
+        }
+        if let Some(max_burst) = self.builder.streaming_max_burst {
+            self.dir.write("streaming_maxburst", max_burst.to_string())?;
+        }
+        if let Some(max_packet) = self.builder.streaming_max_packet {
+            self.dir.write("streaming_maxpacket", max_packet.to_string())?;
+        }
+
+        Ok(())
+    }
+}
+
+/// USB Video Class (UVC) function.
+#[derive(Debug)]
+pub struct Uvc {
+    dir: FunctionDir,
+}
+
+impl Uvc {
+    /// Creates a new USB Video Class (UVC) builder with f_uvc video defaults.
+    pub fn builder() -> UvcBuilder {
+        UvcBuilder { ..Default::default() }
+    }
+
+    /// Creates a new USB Video Class (UVC) with the specified frames.
+    pub fn new(frames: Vec<(u32, u32, UvcFormat)>) -> UvcBuilder {
+        let frames = frames
+            .into_iter()
+            .map(|(width, height, format)| UvcFrame {
+                width,
+                height,
+                // 120, 60, 30, 15 fps
+                intervals: vec![8333, 16666, 33333, 66666],
+                color_matching: None,
+                format,
+            })
+            .collect();
+        UvcBuilder {
+            frames,
+            ..Default::default()
+        }
+    }
+
+    /// Access to registration status.
+    pub fn status(&self) -> Status {
+        self.dir.status()
+    }
+}
+
+pub(crate) fn remove_handler(dir: PathBuf) -> Result<()> {
+    // remove header links for control and streaming
+    for entry in fs::read_dir(dir.join("control/class"))? {
+        let Ok(entry) = entry else { continue };
+        let path = entry.path();
+        let header_path = path.join("h");
+        if header_path.is_symlink() {
+            log::debug!("removing UVC header {:?}", path);
+            fs::remove_file(header_path)?;
+        }
+    }
+    for entry in fs::read_dir(dir.join("streaming/class"))? {
+        let Ok(entry) = entry else { continue };
+        let path = entry.path();
+        let header_path = path.join("h");
+        if header_path.is_symlink() {
+            log::debug!("removing UVC header {:?}", path);
+            fs::remove_file(header_path)?;
+        }
+    }
+
+    // remove all UVC frames, color matching information and header links
+    for format in UvcFormat::all() {
+        // remove header link first to allow removing frames
+        let header_link_path = dir.join(format.header_link_path());
+        if header_link_path.is_symlink() {
+            log::debug!("removing UVC header link {:?}", header_link_path);
+            fs::remove_file(header_link_path)?;
+        }
+
+        let group_dir = dir.join(format.group_path());
+        for entry in fs::read_dir(&group_dir)? {
+            let Ok(entry) = entry else { continue };
+            let path = entry.path();
+            if path.is_dir() {
+                log::debug!("removing UVC frame {:?}", path);
+                fs::remove_dir(path)?;
+            }
+        }
+
+        let color_matching_dir = dir.join(format.color_matching_path());
+        if color_matching_dir.is_dir() {
+            log::debug!("removing UVC color matching information {:?}", color_matching_dir);
+            fs::remove_dir(color_matching_dir)?;
+        }
+
+        log::debug!("removing UVC group {:?}", group_dir);
+        fs::remove_dir(group_dir)?;
+    }
+
+    // finally remove header folders
+    log::debug!("removing UVC headers");
+    fs::remove_dir(dir.join("streaming/header/h"))?;
+    fs::remove_dir(dir.join("control/header/h"))?;
+
+    Ok(())
+}

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,7 +1,7 @@
 mod common;
 use common::*;
 
-use usb_gadget::function::video::{Uvc, UvcFormat, UvcColorMatching};
+use usb_gadget::function::video::{Uvc, UvcColorMatching, UvcFormat};
 
 #[test]
 fn video() {

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,7 +1,7 @@
 mod common;
 use common::*;
 
-use usb_gadget::function::video::{Uvc, ColorMatching, Format, Frame};
+use usb_gadget::function::video::{ColorMatching, Format, Frame, Uvc};
 
 #[test]
 fn video() {

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -7,7 +7,7 @@ use usb_gadget::function::video::{ColorMatching, Format, Frame, Uvc};
 fn video() {
     init();
 
-    let mut builder = Uvc::new(vec![
+    let mut builder = Uvc::builder().with_frames(vec![
         Frame::new(640, 360, vec![15, 30, 60, 120], Format::Yuyv),
         Frame::new(640, 360, vec![15, 30, 60, 120], Format::Mjpeg),
         Frame::new(1280, 720, vec![30, 60], Format::Mjpeg),

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,0 +1,23 @@
+mod common;
+use common::*;
+
+use usb_gadget::function::video::{Uvc, UvcFormat, UvcColorMatching};
+
+#[test]
+fn video() {
+    init();
+
+    let mut builder = Uvc::new(vec![
+        (640, 480, UvcFormat::Yuyv),
+        (640, 480, UvcFormat::Mjpeg),
+        (1280, 720, UvcFormat::Mjpeg),
+        (1920, 1080, UvcFormat::Mjpeg),
+    ]);
+    //builder.frames[0].color_matching = Some(UvcColorMatching::new(0x4, 0x1, 0x2));
+    let (video, func) = builder.build();
+    let reg = reg(func);
+
+    println!("UVC video device at {}", video.status().path().unwrap().display());
+
+    unreg(reg).unwrap();
+}

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,19 +1,19 @@
 mod common;
 use common::*;
 
-use usb_gadget::function::video::{Uvc, UvcColorMatching, UvcFormat};
+use usb_gadget::function::video::{Uvc, ColorMatching, Format, Frame};
 
 #[test]
 fn video() {
     init();
 
     let mut builder = Uvc::new(vec![
-        (640, 480, UvcFormat::Yuyv),
-        (640, 480, UvcFormat::Mjpeg),
-        (1280, 720, UvcFormat::Mjpeg),
-        (1920, 1080, UvcFormat::Mjpeg),
+        Frame::new(640, 360, vec![15, 30, 60, 120], Format::Yuyv),
+        Frame::new(640, 360, vec![15, 30, 60, 120], Format::Mjpeg),
+        Frame::new(1280, 720, vec![30, 60], Format::Mjpeg),
+        Frame::new(1920, 1080, vec![30], Format::Mjpeg),
     ]);
-    builder.frames[0].color_matching = Some(UvcColorMatching::new(0x4, 0x1, 0x2));
+    builder.frames[0].color_matching = Some(ColorMatching::new(0x4, 0x1, 0x2));
     builder.processing_controls = Some(0x05);
     builder.camera_controls = Some(0x60);
     let (video, func) = builder.build();

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -13,7 +13,9 @@ fn video() {
         (1280, 720, UvcFormat::Mjpeg),
         (1920, 1080, UvcFormat::Mjpeg),
     ]);
-    //builder.frames[0].color_matching = Some(UvcColorMatching::new(0x4, 0x1, 0x2));
+    builder.frames[0].color_matching = Some(UvcColorMatching::new(0x4, 0x1, 0x2));
+    builder.processing_controls = Some(0x05);
+    builder.camera_controls = Some(0x60);
     let (video, func) = builder.build();
     let reg = reg(func);
 


### PR DESCRIPTION
Here's the UVC gadget support.

I think the API makes sense for gadget creation. The UVC is a little different from the others in that it requires a [userspace application to support even enumeration](https://docs.kernel.org/6.12/usb/gadget_uvc.html#the-userspace-application).

I tested with [https://gitlab.freedesktop.org/camera/uvc-gadget](uvc-gadget). Creating the gadget then running `uvc-gadget uvc.usb-gadget0-0` (where 'uvc.usb-gadget0-0' is the function dir) will enumerate with my macOS host - without the application it won't. One can open a camera application and open the device. The default just shows a test pattern but can pass `-i image` or `-s dir` for slideshow.

<img width="745" alt="Screenshot 2024-12-04 at 14 37 14" src="https://github.com/user-attachments/assets/b7128d7d-ce69-4414-92cc-b108faf9d2ff">

Would be cool to make a Rust version of uvc-gadget but think it's beyond the scope of this crate or at least this PR since it would almost certainly add a few extra dependencies. It feels like more of a separate bin crate or perhaps workspace crate. Will explore.
