### PR TITLE
Preserve function addition order by using Vec instead of HashSet

### DIFF
--- a/src/gadget.rs
+++ b/src/gadget.rs
@@ -179,7 +179,7 @@ pub struct Config {
     /// Configuration description string.
     pub description: HashMap<Language, String>,
     /// Functions, i.e. USB interfaces, present in this configuration.
-    pub functions: HashSet<function::Handle>,
+    pub functions: Vec<function::Handle>,
 }
 
 impl Config {
@@ -203,7 +203,7 @@ impl Config {
 
     /// Adds a USB function (interface) to this configuration.
     pub fn add_function(&mut self, function_handle: function::Handle) {
-        self.functions.insert(function_handle);
+        self.functions.push(function_handle);
     }
 
     /// Adds a USB function (interface) to this configuration.


### PR DESCRIPTION
This PR changes the internal representation of `functions` in the `gadget::Config` struct from a `HashSet` to a `Vec`.

The original `HashSet` stores functions without preserving insertion order, leading to arbitrary iteration during binding.

This is primarily motivated by the desire to control the USB descriptor interface order.

Let me know if you have any questions or if any adjustments are needed!

Thanks!